### PR TITLE
Removed dependencies on other mods from Brawl and Grond.

### DIFF
--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -14,14 +14,13 @@
     "modType" : "Templates",
 	
 	"templates" : [ "brawl.json" ],
-
-    "depends" : [ "warzyw-templates" ],
 	
 	"version" : "1.0",
  
     "changelog" :
     {
-        "1.0"   : [ "initial release" ]
+        "1.0"   : [ "initial release" ],
+        "1.01"   : [ "removed parent mod dependency" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/grond/content/grond.json
+++ b/warzyw-templates/Mods/grond/content/grond.json
@@ -19,7 +19,7 @@
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
 				"terrainTypes" : [ "swamp" ],
-				"allowedTowns" : ["greenhouse", "forge", "forge2k"],
+				"bannedTowns" : [ "castle", "tower", "rampart", "stronghold", "fortress", "conflux", "inferno", "dungeon" ],
 				"treasure" :
 				[
 					{

--- a/warzyw-templates/Mods/grond/mod.json
+++ b/warzyw-templates/Mods/grond/mod.json
@@ -1,7 +1,7 @@
 {
     "name" : "grond",
 
-    "description" : "Are you strong enough to walk the path to the other human? There's 1 path between Red and Blue and if you don't hurry, strong AI armies will get in your way. Named after a certain fight in one WoG map (Gauntlet of the Grond in Swords of Night and Day), which was probably named after Morgoth's hammer from Tolkien's Silmarillion. Size L, 2 humans, 6 AIs, Average Road, average timer and sim turns, 160%, standard trades for town and color, leaave AIs' towns as random, 1x111 res, tech res if passage to one of the AIs generates as a guarded portal on the road, you can't beat that guard without big losses and can't go around it.",
+    "description" : "Are you strong enough to walk the path to the other human? There's 1 path between Red and Blue and if you don't hurry, strong AI armies will get in your way. Named after a certain fight in one WoG map (Gauntlet of the Grond in Swords of Night and Day), which was probably named after Morgoth's hammer from Tolkien's Silmarillion. Size L, 2 humans, 6 AIs, Average Road, average timer and sim turns, 160%, standard trades for town and color, leaave AIs' towns as random, 1x111 res, tech res if passage to one of the AIs generates as a guarded portal on the road, you can't beat that guard without big losses and can't go around it Suggested mods: HotA to get non-grass native terrain for Conflux and at least one mod with a new town.",
 
     "author" : "Warzyw647",
 
@@ -14,14 +14,13 @@
     "modType" : "Templates",
 	
 	"templates" : [ "grond.json" ],
-
-    "depends" : [ "warzyw-templates", "hota", "forge", "forge2k", "greenhouse-town" ],
 	
 	"version" : "1.0",
  
     "changelog" :
     {
-        "1.0"   : [ "initial release" ]
+        "1.0"   : [ "initial release" ],
+        "1.01"   : [ "removed dependencies", "updated description with suggested mods" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Removed dependencies on other mods from Brawl and Grond.

Brawl just depended on parent mod. Grond depended on parent mod, hota which it was using to get highlands terrain and a few town mods that I put in the central zone as allowed.

The dependency on hota is no longer needed, because the terrain in the players' halls had been changed to dirt earlier.

The dependency of Grond on the Town mods is no longer needed, because I banned all SoD towns in the middle zone except Necropolis (town bans require issue 1242 solved to work) to make new towns appear there most of the time.

Without that issue solved, the middle zone will just have a random town.

Will check how banning Necropolis as well in that zone will work with 1242 solved and no town mods enabled. After that I'll decide if another change is needed.