### PR TITLE
Density and layout

### DIFF
--- a/warzyw-templates/Mods/brawl/content/brawl.json
+++ b/warzyw-templates/Mods/brawl/content/brawl.json
@@ -29,17 +29,17 @@
 					{
 						"min" : 800,
 						"max" : 800,
-						"density" : 2
+						"density" : 4
 					},
 					{
 						"min" : 1000,
 						"max" : 2100,
-						"density" : 6
+						"density" : 12
 					},
 					{
 						"min" : 3500,
 						"max" : 4900,
-						"density" : 14
+						"density" : 28
 					}
 				]
 			},
@@ -107,17 +107,17 @@
 					{
 						"min" : 100,
 						"max" : 900,
-						"density" : 10
+						"density" : 20
 					},
 					{
 						"min" : 750,
 						"max" : 2000,
-						"density" : 16
+						"density" : 32
 					},
 					{
 						"min" : 2000,
 						"max" : 3500,
-						"density" : 6
+						"density" : 12
 					}
 				]
 			},
@@ -149,14 +149,24 @@
 			{ "a" : "1", "b" : "4", "guard" : 3500 },
 			{ "a" : "2", "b" : "3", "guard" : 3500 },
 			{ "a" : "2", "b" : "4", "guard" : 3500 },
-			{ "a" : "1", "b" : "5", "guard" : 0 },
-			{ "a" : "3", "b" : "5", "guard" : 0 },
-			{ "a" : "1", "b" : "6", "guard" : 0 },
-			{ "a" : "4", "b" : "6", "guard" : 0 },
-			{ "a" : "2", "b" : "7", "guard" : 0 },
-			{ "a" : "3", "b" : "7", "guard" : 0 },
-			{ "a" : "2", "b" : "8", "guard" : 0 },
-			{ "a" : "4", "b" : "8", "guard" : 0 }
+			{ "a" : "1", "b" : "3", "type": "repulsive" },
+			{ "a" : "1", "b" : "4", "type": "repulsive" },
+			{ "a" : "2", "b" : "3", "type": "repulsive" },
+			{ "a" : "2", "b" : "4", "type": "repulsive" },
+			{ "a" : "1", "b" : "5", "type": "wide"},
+			{ "a" : "3", "b" : "5", "type": "wide"},
+			{ "a" : "1", "b" : "6", "type": "wide"},
+			{ "a" : "4", "b" : "6", "type": "wide"},
+			{ "a" : "2", "b" : "7", "type": "wide"},
+			{ "a" : "3", "b" : "7", "type": "wide"},
+			{ "a" : "2", "b" : "8", "type": "wide"},
+			{ "a" : "4", "b" : "8", "type": "wide"},
+			{ "a" : "5", "b" : "6", "type": "fictive"},
+			{ "a" : "5", "b" : "7", "type": "fictive"},
+			{ "a" : "5", "b" : "8", "type": "fictive"},
+			{ "a" : "6", "b" : "7", "type": "fictive"},
+			{ "a" : "6", "b" : "8", "type": "fictive"},
+			{ "a" : "7", "b" : "8", "type": "fictive"}
 		]
 	}
 }

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -20,7 +20,8 @@
     "changelog" :
     {
         "1.0"   : [ "initial release" ],
-        "1.01"   : [ "removed parent mod dependency" ]
+        "1.01"   : [ "removed parent mod dependency" ],
+        "1.02"   : [ "doubled all treasure density", "fictive and repulsive connections added by Warmonger" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/grond/content/grond.json
+++ b/warzyw-templates/Mods/grond/content/grond.json
@@ -25,17 +25,17 @@
 					{
 						"min" : 1000,
 						"max" : 4000,
-						"density" : 10
+						"density" : 20
 					},
 					{
 						"min" : 3000,
 						"max" : 8000,
-						"density" : 8
+						"density" : 16
 					},
 					{
 						"min" : 7000,
 						"max" : 11900,
-						"density" : 5
+						"density" : 10
 					}
 				]
 			},
@@ -59,17 +59,17 @@
 					{
 						"min" : 1000,
 						"max" : 4000,
-						"density" : 10
+						"density" : 20
 					},
 					{
 						"min" : 3000,
 						"max" : 8000,
-						"density" : 8
+						"density" : 16
 					},
 					{
 						"min" : 7000,
 						"max" : 15000,
-						"density" : 6
+						"density" : 12
 					}
 				]
 			},
@@ -111,17 +111,17 @@
 					{
 						"min" : 2000,
 						"max" : 3500,
-						"density" : 5
+						"density" : 10
 					},
 					{
 						"min" : 1500,
 						"max" : 2500,
-						"density" : 8
+						"density" : 16
 					},
 					{
 						"min" : 1000,
 						"max" : 2000,
-						"density" : 10
+						"density" : 20
 					}
 				]
 			},
@@ -166,17 +166,17 @@
 					{
 						"min" : 500,
 						"max" : 2000,
-						"density" : 9
+						"density" : 18
 					},
 					{
 						"min" : 2000,
 						"max" : 5000,
-						"density" : 6
+						"density" : 12
 					},
 					{
 						"min" : 5000,
 						"max" : 8000,
-						"density" : 3
+						"density" : 6
 					}
 				]
 			},
@@ -280,17 +280,17 @@
 					{
 						"min" : 10000,
 						"max" : 15000,
-						"density" : 10
+						"density" : 20
 					},
 					{
 						"min" : 15000,
 						"max" : 20000,
-						"density" : 8
+						"density" : 16
 					},
 					{
 						"min" : 20000,
 						"max" : 30000,
-						"density" : 4
+						"density" : 8
 					}
 				],
 				"mines" :
@@ -395,17 +395,17 @@
 					{
 						"min" : 11000,
 						"max" : 15200,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 15200,
 						"max" : 18900,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 18900,
 						"max" : 25900,
-						"density" : 20
+						"density" : 40
 					}
 				]
 			},
@@ -464,17 +464,17 @@
 					{
 						"min" : 36800,
 						"max" : 47700,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 25900,
 						"max" : 36800,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 18900,
 						"max" : 25900,
-						"density" : 20
+						"density" : 40
 					}
 				]
 			},
@@ -533,17 +533,17 @@
 					{
 						"min" : 36800,
 						"max" : 47700,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 25900,
 						"max" : 36800,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 47700,
 						"max" : 59500,
-						"density" : 20
+						"density" : 40
 					}
 				]
 			},
@@ -560,17 +560,17 @@
 					{
 						"min" : 36800,
 						"max" : 47700,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 59500,
 						"max" : 100000,
-						"density" : 20
+						"density" : 40
 					},
 					{
 						"min" : 47700,
 						"max" : 59500,
-						"density" : 20
+						"density" : 40
 					}
 				]
 			}
@@ -602,7 +602,15 @@
 			{ "a" : "14", "b" : "24", "guard" : 7000 },
 			{ "a" : "15", "b" : "25", "guard" : 7000 },
 			{ "a" : "12", "b" : "26", "guard" : 9000 },
-			{ "a" : "13", "b" : "27", "guard" : 9000 }
+			{ "a" : "13", "b" : "27", "guard" : 9000 },
+			{ "a" : "2", "b" : "3", "type": "repulsive" },
+			{ "a" : "4", "b" : "5", "type": "repulsive" },
+			{ "a" : "6", "b" : "7", "type": "repulsive" },
+			{ "a" : "8", "b" : "16", "type": "repulsive" },
+			{ "a" : "9", "b" : "17", "type": "repulsive" },
+			{ "a" : "10", "b" : "14", "type": "repulsive" },
+			{ "a" : "11", "b" : "15", "type": "repulsive" },
+			{ "a" : "11", "b" : "12", "type": "repulsive" }
 		]
 	}
 }

--- a/warzyw-templates/Mods/grond/mod.json
+++ b/warzyw-templates/Mods/grond/mod.json
@@ -20,7 +20,8 @@
     "changelog" :
     {
         "1.0"   : [ "initial release" ],
-        "1.01"   : [ "removed dependencies", "updated description with suggested mods" ]
+        "1.01"   : [ "removed dependencies", "updated description with suggested mods" ],
+        "1.02"   : [ "doubled treasure densities", "added repulsive connections to make the road between the players more straight", "'added repulsive connections to AIs to make them start on both sides of the road" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
 - Doubled treasure densities on Brawl and Grond.
 - Added repulsive and fictive connections to Brawl (made by Warmonger).
 - Added repulsive connections to the zones between the players on Grond to make the path longer, more straight and with less teleports.
 - Added repulsive connections to AI zones on Grond to make them more likely to start on both sides of the road.
Changes to Brawl were checked on 1 generation with Warmonger's new connection options active and the generated map looked more like in HotA.
Changes to Grond require such a check.
