### PR TITLE
Make Banks smaller in Brawl, replace Observatories with Covers of Darkness

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/dragonFlyHive.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/dragonFlyHive.json
@@ -1,0 +1,77 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"dragonFlyHive" : {
+				"resetDuration" : 4,
+				"rmg" : {
+					"value"		: 1000,
+					"rarity"	: 40
+				},
+				"levels": [
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 1, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 2, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 3, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 4, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 5, "type": "lizardman", "upgradeChance": 50 }
+						],
+						"combat_value": 351,
+						"reward" : {
+							"value": 3000,
+							"creatures": [ { "amount": 4, "type": "serpentFly", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 2, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 3, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 4, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 5, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 6, "type": "lizardman", "upgradeChance": 50 }
+						],
+						"combat_value": 702,
+						"reward" : {
+							"value": 6000,
+							"creatures": [ { "amount": 5, "type": "serpentFly", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 3, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 4, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 5, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 6, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 7, "type": "lizardman", "upgradeChance": 50 }
+						],
+						"combat_value": 1053,
+						"reward" : {
+							"value": 9000,
+							"creatures": [ { "amount": 6, "type": "serpentFly", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards": [
+							{ "amount": 4, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 5, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 6, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 7, "type": "lizardman", "upgradeChance": 50 },
+							{ "amount": 8, "type": "lizardman", "upgradeChance": 50 }
+						],
+						"combat_value": 1404,
+						"reward" : {
+							"value": 12000,
+							"creatures": [ { "amount": 7, "type": "serpentFly", "upgradeChance": 50 } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/griffinConservatory.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/griffinConservatory.json
@@ -1,0 +1,75 @@
+{
+	"core:creatureBank" : {
+		"types" : {
+			"griffinConservatory" : {
+				"resetDuration" : 4,
+				"rmg" : {
+					"value"		: 2000,
+					"rarity"	: 40
+				},
+				"levels": [
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 1, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 2, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 3, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 4, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 5, "type": "griffin", "upgradeChance": 50 }
+						],
+						"combat_value": 351,
+						"reward" : {
+							"value": 3000,
+							"creatures": [ { "amount": 2, "type": "monk", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 2, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 3, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 4, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 5, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 6, "type": "griffin", "upgradeChance": 50 }
+						],
+						"combat_value": 702,
+						"reward" : {
+							"value": 6000,
+							"creatures": [ { "amount": 3, "type": "monk", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 3, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 4, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 5, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 6, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 7, "type": "griffin", "upgradeChance": 50 }
+						],
+						"combat_value": 1053,
+						"reward" : {
+							"value": 9000,
+							"creatures": [ { "amount": 4, "type": "monk", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards": [
+							{ "amount": 4, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 5, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 6, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 7, "type": "griffin", "upgradeChance": 50 },
+							{ "amount": 8, "type": "griffin", "upgradeChance": 50 }
+						],
+						"combat_value": 1404,
+						"reward" : {
+							"value": 12000,
+							"creatures": [ { "amount": 5, "type": "monk", "upgradeChance": 50 } ]
+						}
+					}
+				}
+			}
+		]
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/coverOfDarkness.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/coverOfDarkness.json
@@ -1,0 +1,15 @@
+{
+	"core:coverOfDarkness" :
+	{
+		"types":
+		{
+			"object" : {
+				"rmg" : {
+					"zoneLimit"	: 1,
+					"value"		: 750,
+					"rarity"	: 100
+				}
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/redwoodObservatory.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/redwoodObservatory.json
@@ -1,0 +1,13 @@
+{
+	"core:redwoodObservatory" :
+	{
+		"types":
+		{
+			"object" : {
+				"rmg" : {
+					"zoneLimit"	: 0
+				}
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
@@ -1,0 +1,37 @@
+{
+    "name" : "brawlObjects",
+
+    "description" : "Modified objects used by template Brawl",
+
+    "author" : "Warzyw647",
+
+    "licenseName" : "Creative Commons Attribution-ShareAlike",
+
+    "licenseURL" : "https://creativecommons.org/licenses/by-sa/4.0/",
+
+    "contact" : "Warzyw#1628 on heroes-themed Discords",
+
+    "modType" : "Objects",
+	
+	"objects" :
+	[
+		"config/banks/dragonFlyHive.json",
+		"config/banks/griffinConservatory.json",
+		"config/genericObjects/coverOfDarkness.json",
+		"config/genericObjects/redwoodObservatory.json"
+	],
+	
+	"version" : "1.0",
+ 
+    "changelog" :
+    {
+        "1.0"   : [ "disabled Redwood Observatory", "enabled Cover of Darkness", "cons guard lowered and reward changed to Monks", "hives guarded by Lizards and give Serpent Flies" ]
+    },
+
+	"compatibility" :
+	{
+		"min" : "1.3.0"
+	},
+	
+    "keepDisabled" : true
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
@@ -1,7 +1,7 @@
 {
     "name" : "brawlObjects",
 
-    "description" : "Modified objects used by template Brawl",
+    "description" : "Modified objects used by template Brawl, should be better suited for short games on small maps: disabled Redwood Observatories, enabled Covers of Darkness in their place, Cons have guards from 1-5 to 4-8 griffins, rewards 2-5 Monks, each stack can be upgraded, revisitable after 4 days, Hives have guards from 1-5 to 4-8 Lizardmen, reward 4-7 Serpent Flies, also revisitable  after 4 days and also each stack can be upgraded",
 
     "author" : "Warzyw647",
 

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,13 +15,14 @@
 	
 	"templates" : [ "brawl.json" ],
 	
-	"version" : "1.0",
+	"version" : "1.03",
  
     "changelog" :
     {
         "1.0"   : [ "initial release" ],
         "1.01"   : [ "removed parent mod dependency" ],
-        "1.02"   : [ "doubled all treasure density", "fictive and repulsive connections added by Warmonger" ]
+        "1.02"   : [ "doubled all treasure density", "fictive and repulsive connections added by Warmonger" ],
+        "1.03"   : [ "made Griffin Conservatories smaller", "made Dragonfly Hives smaller", "removed Redwood Observatories", "Added Covers of Darkness" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/grond/mod.json
+++ b/warzyw-templates/Mods/grond/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "grond.json" ],
 	
-	"version" : "1.0",
+	"version" : "1.02",
  
     "changelog" :
     {

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,11 +13,12 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.0",
+	"version" : "1.01",
  
     "changelog" :
     {
-        "1.0"   : [ "initial release", "Brawl ported to vcmi", "Grond ported to vcmi"]
+        "1.0"   : [ "initial release", "Brawl ported to vcmi", "Grond ported to vcmi"],
+        "1.01"   : [ " updated Brawl and  Grond  layout", "fixed mod dependencies", "preliminary Brawl object changes", "doubled Brawl and Grond treasures to match their HotA versions"]
     },
 
 	"compatibility" :


### PR DESCRIPTION
 - Changed cons and hives in Brawl,
 - - Griffin Conservatories revisitable after 4 days, guards and rewards changed to:
 - - - 30% chance for guards: 1 Griffin, 2 Griffins, 3 Griffins, 4 Griffins, 5 Griffins, reward: 2 Monks
 - - - 30% chance for guards: 2 Griffin, 3 Griffins, 4 Griffins, 5 Griffins, 6 Griffins, reward: 3 Monks
 - - - 30% chance for guards: 3 Griffin, 4 Griffins, 5 Griffins, 6 Griffins, 7 Griffins, reward: 4 Monks
 - - - 10% chance for guards: 4 Griffin, 5 Griffins, 6 Griffins, 7 Griffins, 8 Griffins, reward: 5 Monks
 - - each guard and reward in con and hive has 50% chance to be upgraded
 - - Dragon Fly Hives revisitable after 4 days, guards and rewards changed to:
 - - - 30% chance for guards: 1 Lizardman, 2 Lizardmen, 3 Lizardmen, 4 Lizardmen, 5 Lizardmen, reward: 4 Serpent Flies
 - - - 30% chance for guards: 2 Lizardmen, 3 Lizardmen, 4 Lizardmen, 5 Lizardmen, 6 Lizardmen, reward: 5 Serpent Flies
 - - - 30% chance for guards: 3 Lizardmen, 4 Lizardmen, 5 Lizardmen, 6 Lizardmen, 7 Lizardmen, reward: 6 Serpent Flies
 - - - 10% chance for guards: 4 Lizardmen, 5 Lizardmen, 6 Lizardmen, 7 Lizardmen, 8 Lizardmen, reward: 7 Serpent Flies
 - - Hive value down to 1k, rarity down to 40
 - - Cons value stays at 2k, rarity down to 40
 - banned Redwood Observatories and added Covers of Darkness with Observatories' value, rarity and limit per zone