### PR TITLE
Bugfixes and soft ban sanctuary object

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/griffinConservatory.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/griffinConservatory.json
@@ -68,8 +68,8 @@
 							"creatures": [ { "amount": 5, "type": "monk", "upgradeChance": 50 } ]
 						}
 					}
-				}
+				]
 			}
-		]
+		}
 	}
 }

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/redwoodObservatory.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/redwoodObservatory.json
@@ -5,7 +5,8 @@
 		{
 			"object" : {
 				"rmg" : {
-					"zoneLimit"	: 0
+					"value"		: 750,
+					"rarity"	: 1
 				}
 			}
 		}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
@@ -1,7 +1,7 @@
 {
     "name" : "brawlObjects",
 
-    "description" : "Modified objects used by template Brawl, should be better suited for short games on small maps: disabled Redwood Observatories, enabled Covers of Darkness in their place, Cons have guards from 1-5 to 4-8 griffins, rewards 2-5 Monks, each stack can be upgraded, revisitable after 4 days, Hives have guards from 1-5 to 4-8 Lizardmen, reward 4-7 Serpent Flies, also revisitable  after 4 days and also each stack can be upgraded",
+    "description" : "Modified objects used by template Brawl, should be better suited for short games on small maps: disabled Sanctuaries and Redwood Observatories, enabled Covers of Darkness in their place, Cons have guards from 1-5 to 4-8 griffins, rewards 2-5 Monks, each stack can be upgraded, revisitable after 4 days, Hives have guards from 1-5 to 4-8 Lizardmen, reward 4-7 Serpent Flies, also revisitable  after 4 days and also each stack can be upgraded",
 
     "author" : "Warzyw647",
 
@@ -18,14 +18,16 @@
 		"config/banks/dragonFlyHive.json",
 		"config/banks/griffinConservatory.json",
 		"config/genericObjects/coverOfDarkness.json",
-		"config/genericObjects/redwoodObservatory.json"
+		"config/genericObjects/redwoodObservatory.json",
+		"config/genericObjects/sanctuary.json"
 	],
 	
-	"version" : "1.0",
+	"version" : "1.01",
  
     "changelog" :
     {
-        "1.0"   : [ "disabled Redwood Observatory", "enabled Cover of Darkness", "cons guard lowered and reward changed to Monks", "hives guarded by Lizards and give Serpent Flies" ]
+        "1.0"   : [ "disabled Redwood Observatory", "enabled Cover of Darkness", "cons guard lowered and reward changed to Monks", "hives guarded by Lizards and give Serpent Flies" ],
+        "1.01"   : [ "fixed bug caused by wrong parentheses in griffinConservatory", "removed sanctuaries" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,14 +15,15 @@
 	
 	"templates" : [ "brawl.json" ],
 	
-	"version" : "1.03",
+	"version" : "1.04",
  
     "changelog" :
     {
         "1.0"   : [ "initial release" ],
         "1.01"   : [ "removed parent mod dependency" ],
         "1.02"   : [ "doubled all treasure density", "fictive and repulsive connections added by Warmonger" ],
-        "1.03"   : [ "made Griffin Conservatories smaller", "made Dragonfly Hives smaller", "removed Redwood Observatories", "Added Covers of Darkness" ]
+        "1.03"   : [ "made Griffin Conservatories smaller", "made Dragonfly Hives smaller", "removed Redwood Observatories", "Added Covers of Darkness" ],
+        "1.04"   : [ "bugfix griffin conservatories in submod wit hobjects crashing the game", "removed Sanctuaries unless rmg really wants them (rarity 1, same as Observatories)" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,12 +13,13 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.01",
+	"version" : "1.02",
  
     "changelog" :
     {
         "1.0"   : [ "initial release", "Brawl ported to vcmi", "Grond ported to vcmi"],
-        "1.01"   : [ " updated Brawl and  Grond  layout", "fixed mod dependencies", "preliminary Brawl object changes", "doubled Brawl and Grond treasures to match their HotA versions"]
+        "1.01"   : [ " updated Brawl and  Grond  layout", "fixed mod dependencies", "preliminary Brawl object changes", "doubled Brawl and Grond treasures to match their HotA versions"],
+        "1.02"   : [ "bugfix in Brawl object changes crashing the game", "Brawl object changes v2" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
 - Fixed wrong parentheses types in griffinConservatory in brawlObjects
 - banned Sanctuary
 - changed bans to Sanctuary and Observatory to rarity 1 to give rmg an option if no other objects are available in these objects' value ranges; A rare Sanctuary or Observatory is okay, they just shouldn't be too common.