### PR TITLE
Fix missing file for sanctuary ban

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/sanctuary.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/genericObjects/sanctuary.json
@@ -1,0 +1,14 @@
+{
+	"core:sanctuary" :
+	{
+		"types":
+		{
+			"object" : {
+				"rmg" : {
+					"value"		: 100,
+					"rarity"	: 1
+				}
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
@@ -22,12 +22,13 @@
 		"config/genericObjects/sanctuary.json"
 	],
 	
-	"version" : "1.01",
+	"version" : "1.02",
  
     "changelog" :
     {
         "1.0"   : [ "disabled Redwood Observatory", "enabled Cover of Darkness", "cons guard lowered and reward changed to Monks", "hives guarded by Lizards and give Serpent Flies" ],
-        "1.01"   : [ "fixed bug caused by wrong parentheses in griffinConservatory", "removed sanctuaries" ]
+        "1.01"   : [ "fixed bug caused by wrong parentheses in griffinConservatory", "removed sanctuaries" ],
+        "1.02"   : [ "added the file with sanctuary ban forgotten in the previous version" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "brawl.json" ],
 	
-	"version" : "1.04",
+	"version" : "1.05",
  
     "changelog" :
     {
@@ -23,7 +23,8 @@
         "1.01"   : [ "removed parent mod dependency" ],
         "1.02"   : [ "doubled all treasure density", "fictive and repulsive connections added by Warmonger" ],
         "1.03"   : [ "made Griffin Conservatories smaller", "made Dragonfly Hives smaller", "removed Redwood Observatories", "Added Covers of Darkness" ],
-        "1.04"   : [ "bugfix griffin conservatories in submod wit hobjects crashing the game", "removed Sanctuaries unless rmg really wants them (rarity 1, same as Observatories)" ]
+        "1.04"   : [ "bugfix griffin conservatories in submod wit hobjects crashing the game", "removed Sanctuaries unless rmg really wants them (rarity 1, same as Observatories)" ],
+        "1.05"   : [ "added the missing file with sanctuary ban in submod brawlObjects" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,13 +13,14 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.02",
+	"version" : "1.03",
  
     "changelog" :
     {
         "1.0"   : [ "initial release", "Brawl ported to vcmi", "Grond ported to vcmi"],
         "1.01"   : [ " updated Brawl and  Grond  layout", "fixed mod dependencies", "preliminary Brawl object changes", "doubled Brawl and Grond treasures to match their HotA versions"],
-        "1.02"   : [ "bugfix in Brawl object changes crashing the game", "Brawl object changes v2" ]
+        "1.02"   : [ "bugfix in Brawl object changes crashing the game", "Brawl object changes v2" ],
+        "1.03"   : [ "added a missing file in Brawl object changes" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Forgot to git add the file with sanctuary ban. Did that now.
Updated mod version numbers to trigger update in case somebody updates to the previous version.