### PR TITLE
Brawl smaller Ziggurat from Pavilion

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlPavilionObjects/content/config/banks/sphinxZiggurat.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlPavilionObjects/content/config/banks/sphinxZiggurat.json
@@ -1,0 +1,236 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"sphinxZiggurat" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit"	: 2,
+					"value"		: 2000,
+					"rarity"	: 100
+				},
+				"levels":
+				[
+					{
+						"chance": 5,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 4,
+								"gems" : 4,
+								"gold" : 1500
+							},
+						"spells": [ { "school" : "air" }, { "school" : "water" } ]
+						}
+					},
+					{
+						"chance": 5,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 4,
+								"gems" : 4,
+								"gold" : 1500
+							},
+						"spells": [ { "school" : "air" }, { "school" : "fire" } ]
+						}
+					},
+					{
+						"chance": 5,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 4,
+								"gems" : 4,
+								"gold" : 1500
+							},
+						"spells": [ { "school" : "air" }, { "school" : "earth" } ]
+						}
+					},
+					{
+						"chance": 5,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 4,
+								"gems" : 4,
+								"gold" : 1500
+							},
+						"spells": [ { "school" : "water" }, { "school" : "fire" } ]
+						}
+					},
+					{
+						"chance": 5,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 4,
+								"gems" : 4,
+								"gold" : 1500
+							},
+						"spells": [ { "school" : "water" }, { "school" : "earth" } ]
+						}
+					},
+					{
+						"chance": 5,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 4,
+								"gems" : 4,
+								"gold" : 1500
+							},
+						"spells": [ { "school" : "fire" }, { "school" : "earth" } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 6,
+								"gems" : 6,
+								"gold" : 2000
+							},
+						"spells": [ { "school" : "water" }, { "school" : "fire" }, { "school" : "earth" } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 6,
+								"gems" : 6,
+								"gold" : 2000
+							},
+						"spells": [ { "school" : "air" }, { "school" : "fire" }, { "school" : "earth" } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 6,
+								"gems" : 6,
+								"gold" : 2000
+							},
+						"spells": [ { "school" : "air" }, { "school" : "water" }, { "school" : "earth" } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 6,
+								"gems" : 6,
+								"gold" : 2000
+							},
+						"spells": [ { "school" : "air" }, { "school" : "water" }, { "school" : "fire" } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 },
+							{ "amount": 1, "type": "sphinx", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"crystal" : 8,
+								"gems" : 8,
+								"gold" : 2500
+							},
+						"spells": [ { "school" : "air" }, { "school" : "water" }, { "school" : "fire" }, { "school" : "earth" } ]
+						}
+					},
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlPavilionObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlPavilionObjects/mod.json
@@ -1,0 +1,39 @@
+{
+    "name" : "brawlPavilionObjects",
+
+    "description" : "Modified Pavilion Town objects used by template Brawl, should be better suited for short games on small maps.<br>Ziggurat: defended by 3-5x 1 Sphinx, reward: 1500-2500 Gold, 4-8 Crystals and Gems, 2-4 Spells from different Schools<br>The Snake Temple Creature Bank is left as it is. It's power is actually okay as a rare slightly (but not too much!) bigger non-rechargable bank.<br>All creatures that have upgrades, both guards and rewards have a chance of being upgraded.<br>All banks recharge after 4 full days pass.<br>They are not designed to be taken with your whole army but with parts of your army in multiple places at once.",
+
+    "author" : "Warzyw647",
+
+    "licenseName" : "Creative Commons Attribution-ShareAlike",
+
+    "licenseURL" : "https://creativecommons.org/licenses/by-sa/4.0/",
+
+    "contact" : "warzyw647 on heroes-themed Discords",
+
+    "modType" : "Objects",
+	
+	"objects" :
+	[
+		"config/banks/sphinxZiggurat.json"
+	],
+	
+	"version" : "1.0",
+
+ 	"depends" : 
+	[
+		"new-pavilion"
+	],
+
+    "changelog" :
+    {
+        "1.0"   : [ "made banks smaller" ]
+    },
+
+	"compatibility" :
+	{
+		"min" : "1.5.6"
+	},
+	
+    "keepDisabled" : true
+}

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "brawl.json", "brawl-ffa.json" ],
 	
-	"version" : "1.15",
+	"version" : "1.16",
  
     "changelog" :
     {
@@ -34,7 +34,8 @@
         "1.12"   : [ "added smaller versions of the Abyss Town creature banks", "enabled Water" ],
         "1.13"   : [ "added smaller version of Antagarich Burning's Grand Conflux" ],
         "1.14"   : [ "added smaller versions of the Cetatea Town's Ancient Citadel" ],
-        "1.15"   : [ "added smaller versions of the Fairy Town's Fairies Bank" ]
+        "1.15"   : [ "added smaller versions of the Fairy Town's Fairies Bank" ],
+        "1.16"   : [ "added smaller versions of the Pavilion Town's Ziggurat" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,7 +13,7 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.15",
+	"version" : "1.16",
  
     "changelog" :
     {
@@ -32,7 +32,8 @@
         "1.12"   : [ "added submod with Abyss Town creature banks to Brawl and enabled water" ],
         "1.13"   : [ "added submod with Antagarich Burning creature banks to Brawl" ],
         "1.14"   : [ "added submod with Cetatea Town creature banks to Brawl" ],
-        "1.15"   : [ "added submod with Fairy Town creature banks to Brawl" ]
+        "1.15"   : [ "added submod with Fairy Town creature banks to Brawl" ],
+        "1.16"   : [ "added submod with Pavilion Town creature banks to Brawl" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Pavilion's other Creature Bank, Snake Temple is left as it is. Its power looks OK for Brawl as a bit bigger rare non-rechargeable Bank.