### PR TITLE
Brawl, banks from Tartarus Town

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlTartarusObjects/content/config/banks/furyBank.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTartarusObjects/content/config/banks/furyBank.json
@@ -1,0 +1,89 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"ftfuryBank" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit"	: 3,
+					"value"		: 2500,
+					"rarity"	: 100 // boosted because it is limited to few terrains
+				},
+				"levels":
+				[
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 3, "type" : "tartarc5", "upgradeChance": 20 },
+							{ "amount": 3, "type" : "tartarc6", "upgradeChance": 20 },
+							{ "amount": 2, "type" : "tides-of-war.alternative-creatures:mdtSukkub", "upgradeChance": 20 },
+							{ "amount": 2, "type" : "tides-of-war.alternative-creatures:mdtLilim", "upgradeChance": 20 }
+						],
+						"reward" : {
+							"resources": 
+							{
+								"gold" : 600,
+								"mercury" : 2,
+								"sulfur" : 2
+							}
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 4, "type" : "tartarc5", "upgradeChance": 20 },
+							{ "amount": 4, "type" : "tartarc6", "upgradeChance": 20 },
+							{ "amount": 3, "type" : "tides-of-war.alternative-creatures:mdtSukkub", "upgradeChance": 20 },
+							{ "amount": 3, "type" : "tides-of-war.alternative-creatures:mdtLilim", "upgradeChance": 20  }
+						],
+						"reward" : {
+							"resources": 
+							{
+								"gold" : 800,
+								"mercury" : 3,
+								"sulfur" : 3
+							}
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 5, "type" : "tartarc5", "upgradeChance": 20 },
+							{ "amount": 5, "type" : "tartarc6", "upgradeChance": 20 },
+							{ "amount": 4, "type" : "tides-of-war.alternative-creatures:mdtSukkub", "upgradeChance": 20 },
+							{ "amount": 4, "type" : "tides-of-war.alternative-creatures:mdtLilim", "upgradeChance": 20  }
+						],
+						"reward" : {
+							"resources": 
+							{
+								"gold" : 1000,
+								"mercury" : 5,
+								"sulfur" : 5
+							}
+						}
+					},
+					{
+						"chance": 10,
+						"guards": [
+							{ "amount": 6, "type" : "tartarc5", "upgradeChance": 20 },
+							{ "amount": 6, "type" : "tartarc6", "upgradeChance": 20 },
+							{ "amount": 5, "type" : "tides-of-war.alternative-creatures:mdtSukkub", "upgradeChance": 20 },
+							{ "amount": 5, "type" : "tides-of-war.alternative-creatures:mdtLilim", "upgradeChance": 20 }
+						],
+						"reward" : {
+							"resources": 
+							{
+								"gold" : 1200,
+								"mercury" : 7,
+								"sulfur" : 7
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTartarusObjects/content/config/banks/iceBank.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTartarusObjects/content/config/banks/iceBank.json
@@ -1,0 +1,90 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"ftIceBank" : {
+				"resetDuration" : 4,
+				"rmg" : {
+					"zoneLimit"	: 3,
+					"value"		: 1500,
+					"rarity"	: 200 // boosted because it is limited to few terrains
+				},
+				"levels": [
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 10, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 10, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 10, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 10, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 10, "type": "tartarc1", "upgradeChance": 50 }
+						],
+						"reward" : {
+							"resources":
+							{
+								"mercury" : 2,
+								"gold" : 500
+							},
+							"creatures": [ { "amount": 4, "type": "tartarc3", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 13, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 13, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 13, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 13, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 13, "type": "tartarc1", "upgradeChance": 50 }
+						],
+						"reward" : {
+							"resources":
+							{
+								"mercury" : 3,
+								"gold" : 650
+							},
+							"creatures": [ { "amount": 3, "type": "tartarc5", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 16, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 16, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 16, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 16, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 16, "type": "tartarc1", "upgradeChance": 50 }
+						],
+						"reward" : {
+							"resources":
+							{
+								"mercury" : 3,
+								"gold" : 800
+							},
+							"creatures": [ { "amount": 2, "type": "tartarc7", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards": [
+							{ "amount": 20, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 20, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 20, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 20, "type": "tartarc1", "upgradeChance": 50 },
+							{ "amount": 20, "type": "tartarc1", "upgradeChance": 50 }
+						],
+						"reward" : {
+							"resources":
+							{
+								"mercury" : 4,
+								"gold" : 1000
+							},
+							"creatures": [ { "amount": 1, "type": "tartarc9", "upgradeChance": 50 } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTartarusObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTartarusObjects/mod.json
@@ -1,0 +1,42 @@
+{
+    "name" : "brawlTartarusObjects",
+
+    "description" : "Modified Tartarus Town objects used by template Brawl, should be better suited for short games on small maps.<br>Quasit Cache: 5x 10-20 Ice Spawns, reward: 2-4 Mercury, 500-1000 Gold, 4 Ice Golems/3 Furies/2 Frost Creepers/1 Arachnid,<br>Bloody Tower: 3-6 Furies and Stygain Furies, 2-5 Succubi and Lilims (from Tides of War mod), reward: 600-1200 Gold, 2-7 Mercury and Sulfur.<br>All creatures that have upgrades, both guards and rewards have a chance of being upgraded.<br>All banks recharge after 4 full days pass.<br>They are not designed to be taken with your whole army but with parts of your army in multiple places at once.",
+
+    "author" : "Warzyw647",
+
+    "licenseName" : "Creative Commons Attribution-ShareAlike",
+
+    "licenseURL" : "https://creativecommons.org/licenses/by-sa/4.0/",
+
+    "contact" : "warzyw647 on heroes-themed Discords",
+
+    "modType" : "Objects",
+	
+	"objects" :
+	[
+		"config/banks/iceBank.json",
+		"config/banks/furyBank.json"
+	],
+	
+	"version" : "1.0",
+
+ 	"depends" : 
+	[
+		"tartarus-town",
+		"tides-of-war",
+		"tides-of-war.alternative-creatures"
+	],
+
+    "changelog" :
+    {
+        "1.0"   : [ "made banks smaller" ]
+    },
+
+	"compatibility" :
+	{
+		"min" : "1.5.6"
+	},
+	
+    "keepDisabled" : true
+}

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "brawl.json", "brawl-ffa.json" ],
 	
-	"version" : "1.18",
+	"version" : "1.19",
  
     "changelog" :
     {
@@ -37,7 +37,8 @@
         "1.15"   : [ "added smaller versions of the Fairy Town's Fairies Bank" ],
         "1.16"   : [ "added smaller versions of the Haven Town's Pirate Keep" ],
         "1.17"   : [ "added smaller versions of the Pavilion Town's Ziggurat" ],
-        "1.18"   : [ "new version of HotA's maxi Pirate Cavern" ]
+        "1.18"   : [ "new version of HotA's maxi Pirate Cavern" ],
+        "1.19"   : [ "added smaller versions of the Tartarus Town's Quasit Cache and Bloody Tower" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,7 +13,7 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.18",
+	"version" : "1.19",
  
     "changelog" :
     {
@@ -35,7 +35,8 @@
         "1.15"   : [ "added submod with Fairy Town creature banks to Brawl" ],
         "1.16"   : [ "added submod with Haven Town creature banks to Brawl" ],
         "1.17"   : [ "added submod with Pavilion Town creature banks to Brawl" ],
-        "1.18"   : [ "new version of HotA's maxi Pirate Cavern in Brawl" ]
+        "1.18"   : [ "new version of HotA's maxi Pirate Cavern in Brawl" ],
+        "1.19"   : [ "added submod with Tartarus Town creature banks to Brawl" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Quasit Cache changed like Imp Cache (gives 1-4 level 2-5 creatures, guards lowered to 5x 10-20, 50% upgrade chance for each stack)
Bloody Tower just lowered guard counts and gold rewards 5 times.
Requires fixing this: https://github.com/vcmi-mods/tartarus-town/issues/19