### PR TITLE
Sim City fix and alt guards

### DIFF
--- a/warzyw-templates/Mods/sim-city/content/sim-city.json
+++ b/warzyw-templates/Mods/sim-city/content/sim-city.json
@@ -20,6 +20,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"2" : // player 1
@@ -40,6 +55,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"3" : // player 2
@@ -60,6 +90,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"4" : // player 3
@@ -80,6 +125,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"5" : // player 4
@@ -100,6 +160,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"6" : // player 5
@@ -120,6 +195,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"7" : // player 6
@@ -140,6 +230,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"8" : // player 7
@@ -160,6 +265,21 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			},
 			"9" : // player 8
@@ -180,11 +300,42 @@
 				"monsters" : "strong",
 				"treasure" :
 				[
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					},
+					{
+						"min" : 10,
+						"max" : 10,
+						"density" : 5
+					}
 				]
 			}
 		},
 		"connections" :
 		[
+			{ "a" : "1", "b" : "2", "guard" : 100000, "road" : "false" },
+			{ "a" : "2", "b" : "3", "guard" : 100000, "road" : "false" },
+			{ "a" : "1", "b" : "3", "guard" : 100000, "road" : "false" },
+			{ "a" : "3", "b" : "4", "guard" : 100000, "road" : "false" },
+			{ "a" : "1", "b" : "4", "guard" : 100000, "road" : "false" },
+			{ "a" : "4", "b" : "5", "guard" : 100000, "road" : "false" },
+			{ "a" : "1", "b" : "5", "guard" : 100000, "road" : "false" },
+			{ "a" : "5", "b" : "6", "guard" : 100000, "road" : "false" },
+			{ "a" : "1", "b" : "6", "guard" : 100000, "road" : "false" },
+			{ "a" : "6", "b" : "7", "guard" : 100000, "road" : "false" },
+			{ "a" : "1", "b" : "7", "guard" : 100000, "road" : "false" },
+			{ "a" : "7", "b" : "8", "guard" : 100000, "road" : "false" },
+			{ "a" : "1", "b" : "8", "guard" : 100000, "road" : "false" },
+			{ "a" : "8", "b" : "9", "guard" : 100000, "road" : "false" },
+			{ "a" : "1", "b" : "9", "guard" : 100000, "road" : "false" },
+			{ "a" : "9", "b" : "2", "guard" : 100000, "road" : "false" },
 			{ "a" : "1", "b" : "2", "guard" : 100000, "road" : "false" },
 			{ "a" : "2", "b" : "3", "guard" : 100000, "road" : "false" },
 			{ "a" : "1", "b" : "3", "guard" : 100000, "road" : "false" },

--- a/warzyw-templates/Mods/sim-city/mod.json
+++ b/warzyw-templates/Mods/sim-city/mod.json
@@ -15,14 +15,15 @@
 	
 	"templates" : [ "sim-city.json" ],
 	
-	"version" : "1.03",
+	"version" : "1.04",
  
     "changelog" :
     {
         "1.0"   : [ "initial release" ],
         "1.01"   : [ "limited version for in branch 1.3 to vcmi 1.3.x and added branch 1.4 for vcmi versions 1.4+" ],
         "1.02"   : [ "added human player limit instead of ai player limit for compatibility with 1.4", "added linebreaks in mod description" ],
-        "1.03"   : [ "updated contact info" ]
+        "1.03"   : [ "updated contact info" ],
+		"1.04"   : [ "fixed error with missing towns by using fake treasure", "alternative guards on all connections" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/sim-city/mod.json
+++ b/warzyw-templates/Mods/sim-city/mod.json
@@ -23,7 +23,7 @@
         "1.01"   : [ "limited version for in branch 1.3 to vcmi 1.3.x and added branch 1.4 for vcmi versions 1.4+" ],
         "1.02"   : [ "added human player limit instead of ai player limit for compatibility with 1.4", "added linebreaks in mod description" ],
         "1.03"   : [ "updated contact info" ],
-		"1.04"   : [ "fixed error with missing towns by using fake treasure", "alternative guards on all connections" ]
+        "1.04"   : [ "fixed error with missing towns by using fake treasure", "alternative guards on all connections" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,7 +13,7 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.20",
+	"version" : "1.21",
  
     "changelog" :
     {
@@ -37,7 +37,8 @@
         "1.17"   : [ "added submod with Pavilion Town creature banks to Brawl" ],
         "1.18"   : [ "new version of HotA's maxi Pirate Cavern in Brawl" ],
         "1.19"   : [ "added submod with Tartarus Town creature banks to Brawl" ],
-        "1.20"   : [ "added submod with Refugee Town creature banks and creatures to Brawl" ]
+        "1.20"   : [ "added submod with Refugee Town creature banks and creatures to Brawl" ],
+        "1.21"   : [ "fixed error with missing towns in Sim City", "alternative guards on all connections in Sim City" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Fixed error with missing towns in Sim City by using fake treasure
Added alternative guards on all connections in Sim City (2 connections instead of 1 between each pair of connected zones)
That's the 1.21 version of the mod as mentioned here: https://github.com/vcmi/vcmi/issues/4676 and here: https://github.com/vcmi/vcmi/issues/4674
For issue 4674 this is a workaround and issue 4676 is a really minor issues for this template.