### PR TITLE
Brawl Tides of War banks

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtBonePillar.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtBonePillar.json
@@ -1,0 +1,85 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"mdtBonePillar" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit" : 1,
+					"mapLimit" : 4,
+					"value" : 2500,
+					"rarity" : 100
+				},
+				"levels":
+				[
+					{
+						"chance": 50,
+						"guards":
+						[
+							{ "amount" : 1, "type" : "mdtGhost", "upgradeChance": 50 }, // in case they ever get an upgrade
+							{ "amount" : 1, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtGhost", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"gold" : 1000
+							},
+							"creatures": [ { "amount": 2, "type": "mdtGhost", "upgradeChance": 50 } ] // in case they ever get an upgrade
+						}
+					},
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount" : 2, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtGhost", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"gold" : 1500
+							},
+							"creatures": [ { "amount": 3, "type": "mdtGhost", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 20,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtGhost", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtGhost", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources":
+							{
+								"gold" : 2000
+							},
+							"creatures": [ { "amount": 4, "type": "mdtGhost", "upgradeChance": 50 } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtOutpostOfSouls.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtOutpostOfSouls.json
@@ -1,0 +1,55 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"mdtOutpostOfSouls" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit" : 1,
+					"value" : 3000,
+					"rarity" : 50
+				},
+				"levels":
+				[
+					{
+						"chance": 80,
+						"guards":
+						[
+							{ "amount" : 1, "type" : "powerLich", "upgradeChance": 50 }, // in case they get an upgrade somewhere
+							{ "amount" : 1, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "powerLich", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"creatures": [ { "amount": 1, "type": "mdtDemilich", "upgradeChance": 50 } ] // in case they ever get an upgrade
+						}
+					},
+					{
+						"chance": 20,
+						"guards":
+						[
+							{ "amount" : 2, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "powerLich", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "powerLich", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"artifacts" : [ "mdtMinorPhylactery" ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtPhantomShip.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtPhantomShip.json
@@ -1,0 +1,160 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"mdtDreadSkipperBankWater" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit" : 3,
+					"value" : 2000,
+					"rarity" : 100
+				},
+				"levels":
+				[
+					{
+						"chance": 50,
+						"guards":
+						[
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 }, // in case they ever get an upgrade
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 1500
+							},
+							"creatures": [ { "amount": 4, "type": "mdtDreadSkipper", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 2000
+							},
+							"creatures": [ { "amount": 6, "type": "mdtDreadSkipper", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 20,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 2500
+							},
+							"creatures": [ { "amount": 8, "type": "mdtDreadSkipper", "upgradeChance": 50 } ]
+						}
+					}
+				]
+			},
+			"mdtDreadSkipperBankLand" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit" : 3,
+					"value" : 2000,
+					"rarity" : 50
+				},
+				"levels":
+				[
+					{
+						"chance": 50,
+						"guards":
+						[
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 1, "type" : "mdtDreadSkipper", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 1000
+							},
+							"creatures": [ { "amount": 2, "type": "mdtDreadSkipper", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 2, "type" : "mdtDreadSkipper", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 1500
+							},
+							"creatures": [ { "amount": 4, "type": "mdtDreadSkipper", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 20,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 },
+							{ "amount" : 3, "type" : "mdtDreadSkipper", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 2000
+							},
+							"creatures": [ { "amount": 6, "type": "mdtDreadSkipper", "upgradeChance": 50 } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtScriptorium.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtScriptorium.json
@@ -1,0 +1,110 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"mdtScriptorium" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit" : 1,
+					"value" : 2000,
+					"rarity" : 50
+				},
+				"levels":
+				[
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 75 },
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 1250,
+								"gems" : 1
+							},
+							"spells" : [ { "level" : 1 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 75 },
+							{ "amount" : 2, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "monk", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"resources" : 
+							{
+								"gold" : 1625,
+								"gems" : 2,
+								"crystal" : 2
+							},
+							"spells" : [ { "level" : 1 } ],
+							"artifacts" : [ { "class" : "MINOR" } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount" : 2, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "monk", "upgradeChance" : 75 },
+							{ "amount" : 2, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "monk", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 2000,
+								"gems" : 3,
+								"crystal" : 3,
+								"sulfur" : 3
+							},
+							"spells" : [ { "level" : 2 } ],
+							"artifacts" : [ { "class" : "MINOR" } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 3, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 3, "type" : "monk", "upgradeChance" : 75 },
+							{ "amount" : 3, "type" : "monk", "upgradeChance" : 50 },
+							{ "amount" : 3, "type" : "monk", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"resources" :
+							{
+								"gold" : 2750,
+								"gems" : 4,
+								"crystal" : 4,
+								"sulfur" : 4,
+								"mercury" : 4
+							},
+							"spells" : [ { "level" : 2 } ],
+							"artifacts" : [ { "class" : "TREASURE" }, { "class" : "MAJOR" } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtSeminarium.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtSeminarium.json
@@ -1,0 +1,81 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"mdtSeminarium" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit" : 1,
+					"value" : 1500,
+					"rarity" : 60
+				},
+				"levels":
+				[
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount": 6, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 6, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 6, "type": "pikeman", "upgradeChance": 75 },
+							{ "amount": 6, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 6, "type": "pikeman", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"creatures": [ { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards":
+						[
+							{ "amount": 8, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 8, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 8, "type": "pikeman", "upgradeChance": 75 },
+							{ "amount": 8, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 8, "type": "pikeman", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"creatures": [ { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 20,
+						"guards":
+						[
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 75 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"creatures": [ { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 }, { "amount": 1, "type": "swordsman", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 20,
+						"guards":
+						[
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 75 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 },
+							{ "amount": 10, "type": "pikeman", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"creatures": [ { "amount": 1, "type": "mdtTemplar", "upgradeChance": 50 } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtSorceressCastle.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/content/config/banks/wtSorceressCastle.json
@@ -1,0 +1,742 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"sorceressCastle" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit" : 1,
+					"mapLimit" : 6,
+					"value" : 2000,
+					"rarity" : 100
+				},
+				"levels":
+				[
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "legsOfLegion", "everpouringVialOfMercury" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "legsOfLegion", "eversmokingRingOfSulfur" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "legsOfLegion", "everflowingCrystalCloak" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "legsOfLegion", "ringOfInfiniteGems" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "loinsOfLegion", "everpouringVialOfMercury" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "loinsOfLegion", "eversmokingRingOfSulfur" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "loinsOfLegion", "everflowingCrystalCloak" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "loinsOfLegion", "ringOfInfiniteGems" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "torsoOfLegion", "everpouringVialOfMercury" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "torsoOfLegion", "eversmokingRingOfSulfur" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "torsoOfLegion", "everflowingCrystalCloak" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "torsoOfLegion", "ringOfInfiniteGems" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "armsOfLegion", "everpouringVialOfMercury" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "armsOfLegion", "eversmokingRingOfSulfur" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "armsOfLegion", "everflowingCrystalCloak" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "armsOfLegion", "ringOfInfiniteGems" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "headOfLegion", "everpouringVialOfMercury" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "headOfLegion", "eversmokingRingOfSulfur" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "headOfLegion", "everflowingCrystalCloak" ]
+						}
+					},
+					{
+						"chance": 3,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtMermaid", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 2 }, { "level" : 3 } ],
+							"artifacts" : [ "headOfLegion", "ringOfInfiniteGems" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "legsOfLegion", "inexhaustibleCartOfOre", "inexhaustibleCartOfLumber" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "legsOfLegion", "endlessPurseOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "legsOfLegion", "endlessBagOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "legsOfLegion", "endlessSackOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "loinsOfLegion", "inexhaustibleCartOfOre", "inexhaustibleCartOfLumber" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "loinsOfLegion", "endlessPurseOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "loinsOfLegion", "endlessBagOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "loinsOfLegion", "endlessSackOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "torsoOfLegion", "inexhaustibleCartOfOre", "inexhaustibleCartOfLumber" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "torsoOfLegion", "endlessPurseOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "torsoOfLegion", "endlessBagOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "torsoOfLegion", "endlessSackOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "armsOfLegion", "inexhaustibleCartOfOre", "inexhaustibleCartOfLumber" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "armsOfLegion", "endlessPurseOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "armsOfLegion", "endlessBagOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "armsOfLegion", "endlessSackOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "headOfLegion", "inexhaustibleCartOfOre", "inexhaustibleCartOfLumber" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "headOfLegion", "endlessPurseOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "headOfLegion", "endlessBagOfGold" ]
+						}
+					},
+					{
+						"chance": 2,
+						"guards":
+						[
+							{ "amount" : 3, "type" : "mdtTriton", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtDryad", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtSukkub", "upgradeChance" : 50 },
+							{ "amount" : 2, "type" : "mdtWerewolf", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtIllithid", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtTrollHag", "upgradeChance" : 50 },
+							{ "amount" : 1, "type" : "mdtCouatl", "upgradeChance" : 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 3 }, { "level" : 4 } ],
+							"artifacts" : [ "headOfLegion", "endlessSackOfGold" ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlTidesOfWarObjects/mod.json
@@ -1,0 +1,48 @@
+{
+    "name" : "brawlTidesOfWarObjects",
+
+    "description" : "Modified Tides of War objects used by template Brawl, should be better suited for short games on small maps.<br>Bone Pillar: defended by 7x 1-3 Ghosts, reward: 1000-2000 Gold, 2-4 Ghosts<br>Outpost of Souls: defended by 7x 1-2 Power Liches, reward: 1 Demilich or Minor Phylactery<br>Phantom Ship: defended by 7x 1-3 Dread Skippers, reward: 2-4 Dread Skippers and 1000-2000 Gold on land, 4-8 Dread Skippers and 1500-2500 Gold on water (because getting to any object on water requires a turn of boarding)<br>Scriptorium: defended by 5x 1-3 Monks (guard count lowered 10 times), rewards (Gold rewards halved, rest of rewards left untouched): 1/2/3/4 Gems, 0/2/3/4 Crystals, 0/0/3/4 Sulfur and 0/0/0/4 Mercury, a Level 1 or 2 Spell, 1250/1625/2000/2750 Gold, Artifacts: none/Minor/Minor/Treasure+Major<br>Seminarium: defended by 5x 6/8/10 Pikemen, rewards: 3/4/5 Swordmen or 1 Templar instead of the 5 Swordmen<br>Sorceress Castle: guarded by 3/4 Tritons, 2/0 Mermaids, 2/3 Dryads, 2/3 Succubi, 2/3 Werewolves, 1/2 Illithids, 1/2 Troll Hag and 0/1 Coatl, rewards: a Level 3 Spell, a Level 2 or 4 Spell, a Statue of Legion component, a Coruncopia component or a Golden Goose component or Wood and Ore Carts<br>All banks recharge after 4 full days pass.<br>They are not designed to be taken with your whole army but with parts of your army in multiple places at once.",
+
+    "author" : "Warzyw647",
+
+    "licenseName" : "Creative Commons Attribution-ShareAlike",
+
+    "licenseURL" : "https://creativecommons.org/licenses/by-sa/4.0/",
+
+    "contact" : "warzyw647 on heroes-themed Discords",
+
+    "modType" : "Objects",
+	
+	"objects" :
+	[
+		"config/banks/wtBonePillar.json",
+		"config/banks/wtOutpostOfSouls.json",
+		"config/banks/wtPhantomShip.json",
+		"config/banks/wtScriptorium.json",
+		"config/banks/wtSeminarium.json",
+		"config/banks/wtSorceressCastle.json"
+	],
+	
+	"version" : "1.0",
+
+ 	"depends" : 
+	[
+		"tides-of-war",
+		"tides-of-war.neutral-creatures",
+		"tides-of-war.alternative-creatures",
+		"tides-of-war.artifacts",
+		"tides-of-war.banks"
+	],
+
+    "changelog" :
+    {
+        "1.0"   : [ "made banks smaller" ]
+    },
+
+	"compatibility" :
+	{
+		"min" : "1.5.6"
+	},
+	
+    "keepDisabled" : true
+}

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "brawl.json", "brawl-ffa.json" ],
 	
-	"version" : "1.20",
+	"version" : "1.21",
  
     "changelog" :
     {
@@ -39,7 +39,8 @@
         "1.17"   : [ "added smaller versions of the Pavilion Town's Ziggurat" ],
         "1.18"   : [ "new version of HotA's maxi Pirate Cavern" ],
         "1.19"   : [ "added smaller versions of the Tartarus Town's Quasit Cache and Bloody Tower" ],
-        "1.20"   : [ "added smaller versions of the Refugee Town's Mysterious Lamp", "weakened the Daeva creature" ]
+        "1.20"   : [ "added smaller versions of the Refugee Town's Mysterious Lamp", "weakened the Daeva creature" ],
+        "1.21"   : [ "added smaller versions of the Tides of War's Bone Pillar, Outpost of Souls, Phantom Ship, Scriptorium, Seminarium and Sorceress Castle" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,7 +13,7 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.21",
+	"version" : "1.22",
  
     "changelog" :
     {
@@ -38,7 +38,8 @@
         "1.18"   : [ "new version of HotA's maxi Pirate Cavern in Brawl" ],
         "1.19"   : [ "added submod with Tartarus Town creature banks to Brawl" ],
         "1.20"   : [ "added submod with Refugee Town creature banks and creatures to Brawl" ],
-        "1.21"   : [ "fixed error with missing towns in Sim City", "alternative guards on all connections in Sim City" ]
+        "1.21"   : [ "fixed error with missing towns in Sim City", "alternative guards on all connections in Sim City" ],
+        "1.22"   : [ "added submod with Tides of War creature banks to Brawl" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Bone Pillar:
just less Ghosts but still Ghosts,
Outpost of Souls:
much smalles and rare
top reward is Minor Phylactery,
Phantom Ship:
less Dread Skippers
water version gives a bit more rewards than land version with same guards, Scriptorium:
less Monks and Gold
otherwise untouched,
Seminarium:
defended by Pikemen instead of Swordsmen
gives mostly Swordsmen,
Sorceress Castle:
defended by creatures from the ToW mod that weren't in other banks Gives parts of Legion and Town of Plenty/Goose