### PR TITLE
Brawl Pyramid and Invisible Men

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/pyramid.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/pyramid.json
@@ -1,0 +1,34 @@
+{
+	"core:pyramid" :
+	{
+		"types" :
+		{
+			"pyramid" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit"	: 1,
+					"value" : 4500,
+					"rarity"	: 20
+				},
+				"levels":
+				[
+					{
+						"chance": 100,
+						"guards":
+						[
+							{ "amount": 8, "type": "diamondGolem", "upgradeChance": 50 },
+							{ "amount": 2, "type": "invisibleMan", "upgradeChance": 50 },
+							{ "amount": 2, "type": "invisibleMan", "upgradeChance": 50 }
+						],
+						"reward" :
+						{
+							"spells" : [ { "level" : 5 } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/quarkPalace.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/content/config/banks/quarkPalace.json
@@ -1,0 +1,39 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"quarkPalace" :
+			{
+				"resetDuration" : 4,
+				"rmg" :
+				{
+					"zoneLimit"	: 1,
+					"value" : 4000,
+					"rarity"	: 100
+				},
+				"levels":
+				[
+					{
+						"chance": 100,
+						"guards":
+						[
+							{ "amount": 1, "type" : "invisibleMan" },
+							{ "amount": 1, "type" : "invisibleMan" },
+							{ "amount": 1, "type" : "invisibleMan" },
+							{ "amount": 1, "type" : "invisibleMan" },
+							{ "amount": 1, "type" : "invisibleMan" },
+							{ "amount": 1, "type" : "invisibleMan" },
+							{ "amount": 1, "type" : "invisibleMan" }
+						],
+						"reward" :
+						{
+							"resources": { "gold" : 1500 },
+							"creatures" : [ { "amount": 1, "type": "invisibleMan" } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlObjects/mod.json
@@ -1,7 +1,7 @@
 {
     "name" : "brawlObjects",
 
-    "description" : "Modified objects used by template Brawl, should be better suited for short games on small maps:<br>disabled Sanctuaries, external  Taverns and Stables,<br>disabled Redwood Observatories, enabled Covers of Darkness in their place,<br>Cons have guards from 1-5 to 4-8 griffins, rewards 2-5 Monks, each stack can be upgraded, revisitable after 4 days,<br>Hives have guards from 1-5 to 4-8 Lizardmen, reward 4-7 Serpent Flies, also revisitable  after 4 days and also each stack can be upgraded,<br>also decreased the sizes and rewards of other banks and made them revisitable after 4 days:<br>Cyclop Stockpile: 4x 3-6 Orcs and 1 Cyclop, reward: 1-4 all resources and 2-3 Ogres,<br>Dwarven Treasury: 4x 3-9 dwarfs, 1-2 Pegasi, reward: 1000-2500 Gold, 2-5 Crystals, 1-2 Pegasi or 1 Dendroid/Gold Golem/Diamod Golem,<br>Imp Cache: 5x 10-20 Imps, reward: 2-4 Mercury, 500-1000 Gold, 4 Gogs/3 Hell Hounds/2 Demons/1 Pit Fiend,<br>Medusa Stores: 9-14 Medusas total in 5 stacks, reward: 3-4 Sulfur, 1000-1600 Gold, 2-3 Evil Eyes or Medusas,<br>Naga Bank: 4x 3-6 Gargoyles and 1 Naga, reward: 2-4 Gems, 600-1200 Gold, 5 Dwarfs/5 Gargoyles/2 Medusas/1 Naga,<br>Crypt: 3x8/2x10/10/10 Skeletons, 2x5/2x5/5/5 Walking Deads, 0/0/3/3 Wights, 0/0/1/2 Vampires, rewards: Treasure class Artifact, 799-999 Gold, 0-2 Wights,<br>Derelict Ship: 5x 3/4/5 Water Elementals, reward: 2000 Gold/2500 Gold and Treasure Artifact/3000 Gold and Minor Artifact,<br>Shipwreck: 5x 1-4 Wights, reward: 1-4 Treasure Artifacts,<br>Dragon Utopia: 1 Red Dragon, 1 Green Dragon, 1 Bone Dragon, reward: Treasure, Minor and Major Artifacts and 3000 Gold.<br>All creatures in each bank that have upgrades, both guards and rewards have a chance of being upgraded.",
+    "description" : "Modified objects used by template Brawl, should be better suited for short games on small maps:<br>disabled Sanctuaries, external  Taverns and Stables,<br>disabled Redwood Observatories, enabled Covers of Darkness in their place,<br>Cons have guards from 1-5 to 4-8 griffins, rewards 2-5 Monks, each stack can be upgraded, revisitable after 4 days,<br>Hives have guards from 1-5 to 4-8 Lizardmen, reward 4-7 Serpent Flies, also revisitable  after 4 days and also each stack can be upgraded,<br>also decreased the sizes and rewards of other banks and made them revisitable after 4 days:<br>Cyclop Stockpile: 4x 3-6 Orcs and 1 Cyclop, reward: 1-4 all resources and 2-3 Ogres,<br>Dwarven Treasury: 4x 3-9 dwarfs, 1-2 Pegasi, reward: 1000-2500 Gold, 2-5 Crystals, 1-2 Pegasi or 1 Dendroid/Gold Golem/Diamod Golem,<br>Imp Cache: 5x 10-20 Imps, reward: 2-4 Mercury, 500-1000 Gold, 4 Gogs/3 Hell Hounds/2 Demons/1 Pit Fiend,<br>Medusa Stores: 9-14 Medusas total in 5 stacks, reward: 3-4 Sulfur, 1000-1600 Gold, 2-3 Evil Eyes or Medusas,<br>Naga Bank: 4x 3-6 Gargoyles and 1 Naga, reward: 2-4 Gems, 600-1200 Gold, 5 Dwarfs/5 Gargoyles/2 Medusas/1 Naga,<br>Crypt: 3x8/2x10/10/10 Skeletons, 2x5/2x5/5/5 Walking Deads, 0/0/3/3 Wights, 0/0/1/2 Vampires, rewards: Treasure class Artifact, 799-999 Gold, 0-2 Wights,<br>Derelict Ship: 5x 3/4/5 Water Elementals, reward: 2000 Gold/2500 Gold and Treasure Artifact/3000 Gold and Minor Artifact,<br>Shipwreck: 5x 1-4 Wights, reward: 1-4 Treasure Artifacts,<br>Dragon Utopia: 1 Red Dragon, 1 Green Dragon, 1 Bone Dragon, reward: Treasure, Minor and Major Artifacts and 3000 Gold,<br>Pyramid: 8 Diamond Golems and 2x 2 Invisible Men, reward unchanged,<br>Quark Palace: 7x 1 Invisible Man, reward: 1 Invisible Man, 1500 Gold.<br>All creatures in each bank that have upgrades, both guards and rewards have a chance of being upgraded.",
 
     "author" : "Warzyw647",
 
@@ -26,6 +26,8 @@
 		"config/banks/shipwreck.json",
 		"config/banks/derelictShip.json",
 		"config/banks/dragonUtopia.json",
+		"config/banks/pyramid.json",
+		"config/banks/quarkPalace.json",
 		"config/genericObjects/coverOfDarkness.json",
 		"config/genericObjects/redwoodObservatory.json",
 		"config/genericObjects/sanctuary.json",
@@ -33,8 +35,13 @@
 		"config/genericObjects/stables.json"
 	],
 	
-	"version" : "1.08",
+	"version" : "1.09",
  
+ 	"depends" : 
+	[
+		"invisible-man"
+	],
+	
     "changelog" :
     {
         "1.0"   : [ "disabled Redwood Observatory", "enabled Cover of Darkness", "cons guard lowered and reward changed to Monks", "hives guarded by Lizards and give Serpent Flies" ],
@@ -45,7 +52,8 @@
         "1.05"   : [ "updated Cover of Darkness and Observatory types for compatibility with 1.4", "added linebreaks in mod description" ],
         "1.06"   : [ "updated contact info" ],
         "1.07"   : [ "smaller versions of Shipwreck and Derlict Ship" ],
-        "1.08"   : [ "smaller versions of Dragon Utopia" ]
+        "1.08"   : [ "smaller versions of Dragon Utopia" ],
+        "1.09"   : [ "smaller Pyramid, uses Invisible Man from Invisible Man mod", "smaller Quark Palace from mod Invisible Man" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "brawl.json", "brawl-ffa.json" ],
 	
-	"version" : "1.26",
+	"version" : "1.27",
  
     "changelog" :
     {
@@ -45,7 +45,8 @@
         "1.23"   : [ "added submod with PvP Balance creature banks to Brawl" ],
         "1.24"   : [ "smaller water banks in Brawl Objects submods core, HotA and Haven", "drastically increased treasure densities in Water Zones" ],
         "1.25"   : [ "removed duplicate sound and animation files in HotA Objects submod" ],
-        "1.26"   : [ "smaller versions of Dragon Utopias and Golden Dragon Utopia in Core and PvP Balance Objects submods" ]
+        "1.26"   : [ "smaller versions of Dragon Utopias and Golden Dragon Utopia in Core and PvP Balance Objects submods" ],
+        "1.27"   : [ "smaller version of Pyramid and Quark Palace in Core Objects submod, uses Invisible Men from Invisible Man mod" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,7 +13,7 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.29",
+	"version" : "1.30",
  
     "changelog" :
     {
@@ -46,7 +46,8 @@
         "1.26"   : [ "added submod with PvP Balance creature banks to Brawl" ],
         "1.27"   : [ "smaller water banks in Brawl submods", "increased treasure densities in Water Zones, done in Brawl submod, repeated in its PvP Balance Objects submod" ],
         "1.28"   : [ "removed duplicate sound and animation files in HotA Objects submod of Brawl" ],
-        "1.29"   : [ "smaller Utopias added to PvP balance and Core Objects submods of Brawl" ]
+        "1.29"   : [ "smaller Utopias added to PvP balance and Core Objects submods of Brawl" ],
+        "1.30"   : [ "smaller Pyramid and Quark Palace added to Core Objects submod of Brawl, uses Invisible Man mod" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Added Pyramid to brawlObjects, guarded by 8 Diamond Golems and 2x 2 Invisible Men, reward unchanged (a level 5 spell)
Added Quark Palace from Invisible Man mod to brawlObjects, guarded by 7x1 Invisible Man, gives 1 Invisible Man and 1500 Gold