### PR TITLE
brawl hota objects hota.gamebalance compatibility

### DIFF
--- a/warzyw-templates/Mods/brawl/Mods/brawlHotaObjects/content/config/banks/nagaBank.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlHotaObjects/content/config/banks/nagaBank.json
@@ -1,0 +1,98 @@
+{
+	"core:creatureBank" :
+	{
+		"types" :
+		{
+			"nagaBank" : {
+				"resetDuration" : 4,
+				"rmg" : {
+					"zoneLimit"	: 2,
+					"value"		: 2000,
+					"rarity"	: 100
+				},
+				"levels": [
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 3, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 3, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 3, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 3, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 1, "type": "naga", "upgradeChance": 50 }
+						],
+						"combat_value": 351,
+						"reward" : {
+							"value": 3000,
+							"resources":
+							{
+								"gems" : 2,
+								"gold" : 600
+							},
+							"creatures": [ { "amount": 5, "type": "dwarf", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 4, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 4, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 4, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 4, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 1, "type": "naga", "upgradeChance": 50 }
+						],
+						"combat_value": 702,
+						"reward" : {
+							"value": 6000,
+							"resources":
+							{
+								"gems" : 3,
+								"gold" : 800
+							},
+							"creatures": [ { "amount": 5, "type": "stoneGargoyle", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 30,
+						"guards": [
+							{ "amount": 5, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 5, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 5, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 5, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 1, "type": "naga", "upgradeChance": 50 }
+						],
+						"combat_value": 1053,
+						"reward" : {
+							"value": 9000,
+							"resources":
+							{
+								"gems" : 3,
+								"gold" : 1000
+							},
+							"creatures": [ { "amount": 2, "type": "medusa", "upgradeChance": 50 } ]
+						}
+					},
+					{
+						"chance": 10,
+						"guards": [
+							{ "amount": 6, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 6, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 6, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 6, "type": "stoneGargoyle", "upgradeChance": 50 },
+							{ "amount": 1, "type": "naga", "upgradeChance": 50 }
+						],
+						"combat_value": 1404,
+						"reward" : {
+							"value": 12000,
+							"resources":
+							{
+								"gems" : 4,
+								"gold" : 1200
+							},
+							"creatures": [ { "amount": 1, "type": "naga", "upgradeChance": 50 } ]
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlHotaObjects/content/config/genericObjects/coverOfDarkness.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlHotaObjects/content/config/genericObjects/coverOfDarkness.json
@@ -1,0 +1,15 @@
+{
+	"core:coverOfDarkness" :
+	{
+		"types":
+		{
+			"coverOfDarkness" : {
+				"rmg" : {
+					"zoneLimit"	: 1,
+					"value"		: 750,
+					"rarity"	: 100
+				}
+			}
+		}
+	}
+}

--- a/warzyw-templates/Mods/brawl/Mods/brawlHotaObjects/mod.json
+++ b/warzyw-templates/Mods/brawl/Mods/brawlHotaObjects/mod.json
@@ -25,6 +25,7 @@
 	
 	"objects" :
 	[
+		"config/banks/nagaBank.json",
 		"config/banks/churchyard.json",
 		"config/banks/experimentalShop.json",
 		"config/banks/ivoryTower.json",
@@ -35,17 +36,21 @@
 		"config/banks/wolfRaiderPicket.json",
 		"config/banks/ruins.json",
 		"config/banks/templeOfTheSea.json",
-		"config/banks/beholderSanctuary.json"
+		"config/banks/beholderSanctuary.json",
+		"config/genericObjects/coverOfDarkness.json"
 	],
 	
-	"version" : "1.07",
+	"version" : "1.08",
 
  	"depends" : 
 	[
+		"warzyw-templates.brawl.brawlObjects",
+		"hota",
 		"hota.mapobjects",
 		"hota.neutralcreatures",
 		"hota.cove",
-		"hota.highlandsTerrain"
+		"hota.highlandsTerrain",
+		"hota.gamebalance"
 	],
 
     "changelog" :
@@ -57,7 +62,8 @@
         "1.04"   : [ "new version of maxi Pirate Cavern" ],
         "1.05"   : [ "bumped Ruins value, lowered rarity and zone limit and made them revisitable" ],
         "1.06"   : [ "smaller versions of water banks: Temple Of The Sea and Beholder Sanctuary" ],
-        "1.07"   : [ "the Pirate Copy creature used in the maxi Pirate Cavern now reuses sounds and animations from HotA mod instead copying them" ]
+        "1.07"   : [ "the Pirate Copy creature used in the maxi Pirate Cavern now reuses sounds and animations from HotA mod instead copying them" ],
+        "1.08"   : [ "added dependency on main HotA mod", "repeated some object changes from mod brawlObjects to achieve hota.gameBalance mod compatibility, namely Cover of Darkness and Naga Bank" ],
     },
 
 	"compatibility" :

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "brawl.json", "brawl-ffa.json" ],
 	
-	"version" : "1.27",
+	"version" : "1.28",
  
     "changelog" :
     {
@@ -46,7 +46,8 @@
         "1.24"   : [ "smaller water banks in Brawl Objects submods core, HotA and Haven", "drastically increased treasure densities in Water Zones" ],
         "1.25"   : [ "removed duplicate sound and animation files in HotA Objects submod" ],
         "1.26"   : [ "smaller versions of Dragon Utopias and Golden Dragon Utopia in Core and PvP Balance Objects submods" ],
-        "1.27"   : [ "smaller version of Pyramid and Quark Palace in Core Objects submod, uses Invisible Men from Invisible Man mod" ]
+        "1.27"   : [ "smaller version of Pyramid and Quark Palace in Core Objects submod, uses Invisible Men from Invisible Man mod" ],
+        "1.28"   : [ "added dependency on main HotA mod to HotA Objects submod", "HotA Game Balance submod compatibility in HotA Objects submod" ]
     },
 
 	"compatibility" :

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,7 +13,7 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.30",
+	"version" : "1.31",
  
     "changelog" :
     {
@@ -47,7 +47,8 @@
         "1.27"   : [ "smaller water banks in Brawl submods", "increased treasure densities in Water Zones, done in Brawl submod, repeated in its PvP Balance Objects submod" ],
         "1.28"   : [ "removed duplicate sound and animation files in HotA Objects submod of Brawl" ],
         "1.29"   : [ "smaller Utopias added to PvP balance and Core Objects submods of Brawl" ],
-        "1.30"   : [ "smaller Pyramid and Quark Palace added to Core Objects submod of Brawl, uses Invisible Man mod" ]
+        "1.30"   : [ "smaller Pyramid and Quark Palace added to Core Objects submod of Brawl, uses Invisible Man mod" ],
+        "1.31"   : [ "added dependency on main HotA mod to HotA Objects submod of Brawl", "HotA Game Balance submod compatibility in HotA Objects submod" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
In brawlHotaObjects submod added dependencies on brawlObjects, hota.gameBalance because both touch Naga Bank and Cover of Darkness
Added dependency on hota main mod to better load dependencies
Copied changes to Naga Bank and Cover of Darkness from brawlObjects to overwrite changes to them from hota.gameBalance