### PR TITLE
Disabled brawl submod as default

### DIFF
--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -15,7 +15,7 @@
 	
 	"templates" : [ "brawl.json", "brawl-ffa.json" ],
 	
-	"version" : "1.24",
+	"version" : "1.25",
  
     "changelog" :
     {

--- a/warzyw-templates/Mods/brawl/mod.json
+++ b/warzyw-templates/Mods/brawl/mod.json
@@ -43,7 +43,8 @@
         "1.21"   : [ "added smaller versions of the Tides of War's Bone Pillar, Outpost of Souls, Phantom Ship, Scriptorium, Seminarium and Sorceress Castle" ],
         "1.22"   : [ "value, rarity and revisitability tweaks in HotA's Ruins" ],
         "1.23"   : [ "Fixed ImpCache typo and Water Temple" ],
-        "1.24"   : [ "banks updated to vcmi 1.6 syntax by kdmcser" ]
+        "1.24"   : [ "banks updated to vcmi 1.6 syntax by kdmcser" ],
+        "1.25"   : [ "Disabled Brawl submod by default" ]
     },
 
 	"compatibility" :
@@ -51,7 +52,7 @@
 		"min" : "1.5.6"
 	},
 	
-    "keepDisabled" : false,
+    "keepDisabled" : true,
     "chinese" : {
     	"name" : "小型混战地图模板",
     	"description" : "两个小型混战随机地图模板。<br>brawl模板：单层地图，尺寸从S到M（推荐尺寸48x48），2人对战；<br>brawl-ffa模板：双层地图，尺寸从S+U到M+U（推荐尺寸52x52），4人对战。<br>地图上无道路或只有城镇和矿区间的泥路。<br>建议200%难度开局，不设置同步回合，选择时长较短的计时器。<br>对战规则：双方各掷出一个城镇，再掷硬币，胜方先选择城镇或颜色，负方则选择剩下的。<br>（建议开启【决斗模式】）"

--- a/warzyw-templates/mod.json
+++ b/warzyw-templates/mod.json
@@ -13,7 +13,7 @@
 
     "modType" : "Templates",
 	
-	"version" : "1.27",
+	"version" : "1.28",
  
     "changelog" :
     {
@@ -44,7 +44,8 @@
         "1.24"   : [ "Fixed ImpCache typo and Water Temple" ],
         "1.25"   : [ "Chinese translation by Ziyue" ],
         "1.26"   : [ "Brawl banks updated to vcmi 1.6 syntax by kdmcser" ],
-        "1.27"   : [ "ported last vcmi 1.4 changes in arena to vcmi 1.6", "nerfed Spellbinder's Hat nerf in Arena", "automatically enabled Arena submod, with tournament in mind", "added some Signs, another Observatory and PL translation to Arena" ]
+        "1.27"   : [ "ported last vcmi 1.4 changes in arena to vcmi 1.6", "nerfed Spellbinder's Hat nerf in Arena", "automatically enabled Arena submod, with tournament in mind", "added some Signs, another Observatory and PL translation to Arena" ],
+        "1.28"   : [ "Brawl submod disabled by default" ]
     },
 
 	"compatibility" :


### PR DESCRIPTION
Disabled brawl submod as default as it generate same questions - "Why I have insane amount of resources? Is it bug?"
Please consider to moving this settings into standalone submod in Brawl instead to be able to use templates without insane resources at start.